### PR TITLE
General improvements

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "Pinnable",
     platforms: [
-        .iOS(.v12),
+        .iOS(.v9),
     ],
     products: [
         .library(name: "Pinnable", targets: ["Pinnable"]),

--- a/Sources/Pinnable/NSLayoutAnchor+Extensions.swift
+++ b/Sources/Pinnable/NSLayoutAnchor+Extensions.swift
@@ -14,15 +14,18 @@ extension NSLayoutAnchor {
     ///
     /// - Parameters:
     ///   - anchor: The anchor to constrain the receiver to.
+    ///   - multiplier: An optional multiplier for the constraint. Defaults to 1.
     ///   - constant: An optional constant for the constraint. Defaults to 0.
     ///   - priority: An optional priority for the constraint. Defaults to `.required`.
     /// - Returns: The constraint that was created.
     @objc @discardableResult public func pin(
         to anchor: NSLayoutAnchor<AnchorType>,
+        multiplier: CGFloat = 1,
         constant: CGFloat = 0,
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
         constraint(equalTo: anchor, constant: constant)
+            .copyWith(multiplier: multiplier)
             .prioritize(priority)
             .setUp()
     }
@@ -33,15 +36,18 @@ extension NSLayoutAnchor {
     ///
     /// - Parameters:
     ///   - anchor: The anchor to constrain the receiver to.
+    ///   - multiplier: An optional multiplier for the constraint. Defaults to 1.
     ///   - constant: An optional constant for the constraint. Defaults to 0.
     ///   - priority: An optional priority for the constraint. Defaults to `.required`.
     /// - Returns: The constraint that was created.
     @objc @discardableResult public func pin(
         greaterThan anchor: NSLayoutAnchor<AnchorType>,
+        multiplier: CGFloat = 1,
         constant: CGFloat = 0,
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
         constraint(greaterThanOrEqualTo: anchor, constant: constant)
+            .copyWith(multiplier: multiplier)
             .prioritize(priority)
             .setUp()
     }
@@ -52,15 +58,18 @@ extension NSLayoutAnchor {
     ///
     /// - Parameters:
     ///   - anchor: The anchor to constrain the receiver to.
+    ///   - multiplier: An optional multiplier for the constraint. Defaults to 1.
     ///   - constant: An optional constant for the constraint. Defaults to 0.
     ///   - priority: An optional priority for the constraint. Defaults to `.required`.
     /// - Returns: The constraint that was created.
     @objc @discardableResult public func pin(
         lessThan anchor: NSLayoutAnchor<AnchorType>,
+        multiplier: CGFloat = 1,
         constant: CGFloat = 0,
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
         constraint(lessThanOrEqualTo: anchor, constant: constant)
+            .copyWith(multiplier: multiplier)
             .prioritize(priority)
             .setUp()
     }

--- a/Sources/Pinnable/NSLayoutConstraint+Extensions.swift
+++ b/Sources/Pinnable/NSLayoutConstraint+Extensions.swift
@@ -25,7 +25,7 @@ extension NSLayoutConstraint {
     }
 
     /// Set the priority on the constraint.
-    /// 
+    ///
     /// - Parameter priority: The value of the priority.
     /// - Returns: self
     @discardableResult public func prioritize(_ priority: UILayoutPriority) -> Self {
@@ -33,9 +33,21 @@ extension NSLayoutConstraint {
         return self
     }
 
-    internal func setUp() -> NSLayoutConstraint {
+    internal func setUp() -> Self {
         (firstItem as? UIView)?.translatesAutoresizingMaskIntoConstraints = false
         activate()
         return self
+    }
+
+    internal func copyWith(multiplier: CGFloat) -> Self {
+        .init(
+            item: firstItem as Any,
+            attribute: firstAttribute,
+            relatedBy: relation,
+            toItem: secondItem,
+            attribute: secondAttribute,
+            multiplier: multiplier,
+            constant: constant
+        ).prioritize(priority)
     }
 }

--- a/Sources/Pinnable/NSLayoutDimension+Extensions.swift
+++ b/Sources/Pinnable/NSLayoutDimension+Extensions.swift
@@ -60,7 +60,7 @@ extension NSLayoutDimension {
     ///   - constant: An optional constant for the constraint. Defaults to 0.
     ///   - priority: An optional priority for the constraint. Defaults to `.required`.
     /// - Returns: The constraint that was created.
-    @objc @discardableResult public func pin(
+    @discardableResult public func pin(
         to anchor: NSLayoutDimension,
         multiplier: CGFloat = 1,
         constant: CGFloat = 0,
@@ -81,7 +81,7 @@ extension NSLayoutDimension {
     ///   - constant: An optional constant for the constraint. Defaults to 0.
     ///   - priority: An optional priority for the constraint. Defaults to `.required`.
     /// - Returns: The constraint that was created.
-    @objc @discardableResult public func pin(
+    @discardableResult public func pin(
         greaterThan anchor: NSLayoutDimension,
         multiplier: CGFloat = 1,
         constant: CGFloat = 0,
@@ -102,9 +102,10 @@ extension NSLayoutDimension {
     ///   - constant: An optional constant for the constraint. Defaults to 0.
     ///   - priority: An optional priority for the constraint. Defaults to `.required`.
     /// - Returns: The constraint that was created.
-    @objc @discardableResult public func pin(
+    @discardableResult public func pin(
         lessThan anchor: NSLayoutDimension,
-        multiplier: CGFloat = 1, constant: CGFloat = 0,
+        multiplier: CGFloat = 1,
+        constant: CGFloat = 0,
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
         constraint(lessThanOrEqualTo: anchor, multiplier: multiplier, constant: constant)

--- a/Sources/Pinnable/Pinnable.swift
+++ b/Sources/Pinnable/Pinnable.swift
@@ -26,24 +26,54 @@ public protocol Pinnable: AnyObject {
 
 extension Pinnable {
     /// Constrain the edges of the receiver to the corresponding edges of the provided view or layout guide.
-    /// 
+    ///
+    /// - Parameters:
+    ///   - edges: The edges to constrain. Defaults to `.all`.
+    ///   - object: The object to constrain the receiver to.
+    ///   - insets: Optional insets to apply to the constraints. Defaults to `.zero`.
+    ///   - priority: An optional priority for the constraints. Defaults to `.required`.
+    /// - Returns: A named tuple of the created constraints. The properties are optional, as edges not specified will not have constraints.
+    @available(iOS 13.0, *)
+    @discardableResult public func pinEdges<P: Pinnable>(
+        _ edges: NSDirectionalRectEdge = .all,
+        to object: P,
+        insets: NSDirectionalEdgeInsets = .zero,
+        priority: UILayoutPriority = .required
+    ) -> (top: NSLayoutConstraint?, leading: NSLayoutConstraint?, bottom: NSLayoutConstraint?, trailing: NSLayoutConstraint?) {
+        let top = edges.contains(.top) ? topAnchor.constraint(equalTo: object.topAnchor, constant: insets.top) : nil
+        let leading = edges.contains(.leading) ? leadingAnchor.constraint(equalTo: object.leadingAnchor, constant: insets.leading) : nil
+        let bottom = edges.contains(.bottom) ? bottomAnchor.constraint(equalTo: object.bottomAnchor, constant: -insets.bottom) : nil
+        let trailing = edges.contains(.trailing) ? trailingAnchor.constraint(equalTo: object.trailingAnchor, constant: -insets.trailing) : nil
+
+        disableTranslatesAutoresizingMaskIntoConstraintsIfNeeded()
+        NSLayoutConstraint.activate([top, leading, bottom, trailing].compactMap { $0?.prioritize(priority) })
+
+        return (top: top, leading: leading, bottom: bottom, trailing: trailing)
+    }
+
+    /// Constrain the edges of the receiver to the corresponding edges of the provided view or layout guide.
+    ///
     /// - Parameters:
     ///   - edges: The edges to constrain. The `left` and `right` edge will constrain the `leading` and `trailing` anchors, respectively. Defaults to `.all`.
     ///   - object: The object to constrain the receiver to.
     ///   - insets: Optional insets to apply to the constraints. The top, left, bottom, and right constants will be applied to the top, leading, bottom, and trailing edges, respectively. Defaults to `.zero`.
+    ///   - priority: An optional priority for the constraints. Defaults to `.required`.
     /// - Returns: A named tuple of the created constraints. The properties are optional, as edges not specified will not have constraints.
-    @discardableResult public func pinEdges(
+
+    @available(iOS, deprecated: 13.0, message: "Use leading and trailing instead of left and right, respectively.")
+    @_disfavoredOverload @discardableResult public func pinEdges<P: Pinnable>(
         _ edges: UIRectEdge = .all,
-        to object: Pinnable,
-        insets: UIEdgeInsets = .zero
+        to object: P,
+        insets: UIEdgeInsets = .zero,
+        priority: UILayoutPriority = .required
     ) -> (top: NSLayoutConstraint?, leading: NSLayoutConstraint?, bottom: NSLayoutConstraint?, trailing: NSLayoutConstraint?) {
-        let top = edges.contains(.top) ? topAnchor.pin(to: object.topAnchor, constant: insets.top) : nil
-        let leading = edges.contains(.left) ? leadingAnchor.pin(to: object.leadingAnchor, constant: insets.left) : nil
-        let bottom = edges.contains(.bottom) ? bottomAnchor.pin(to: object.bottomAnchor, constant: -insets.bottom) : nil
-        let trailing = edges.contains(.right) ? trailingAnchor.pin(to: object.trailingAnchor, constant: -insets.right) : nil
+        let top = edges.contains(.top) ? topAnchor.constraint(equalTo: object.topAnchor, constant: insets.top) : nil
+        let leading = edges.contains(.left) ? leadingAnchor.constraint(equalTo: object.leadingAnchor, constant: insets.left) : nil
+        let bottom = edges.contains(.bottom) ? bottomAnchor.constraint(equalTo: object.bottomAnchor, constant: -insets.bottom) : nil
+        let trailing = edges.contains(.right) ? trailingAnchor.constraint(equalTo: object.trailingAnchor, constant: -insets.right) : nil
 
         disableTranslatesAutoresizingMaskIntoConstraintsIfNeeded()
-        NSLayoutConstraint.activate([top, leading, bottom, trailing].compactMap { $0 })
+        NSLayoutConstraint.activate([top, leading, bottom, trailing].compactMap { $0?.prioritize(priority) })
 
         return (top: top, leading: leading, bottom: bottom, trailing: trailing)
     }
@@ -54,12 +84,12 @@ extension Pinnable {
     ///   - object: The object to constrain the receiver to.
     ///   - offset: An optional offset for the constraints. The horizontal offset will be applied to the center X anchor, and the vertical offset will be applied to the center Y anchor. Defaults to `.zero`.
     /// - Returns: A named tuple of the created constraints.
-    @discardableResult public func pinCenter(
-        to object: Pinnable,
+    @discardableResult public func pinCenter<P: Pinnable>(
+        to object: P,
         offset: UIOffset = .zero
     ) -> (x: NSLayoutConstraint, y: NSLayoutConstraint) {
-        let centerX = centerXAnchor.pin(to: object.centerXAnchor, constant: offset.horizontal)
-        let centerY = centerYAnchor.pin(to: object.centerYAnchor, constant: offset.vertical)
+        let centerX = centerXAnchor.constraint(equalTo: object.centerXAnchor, constant: offset.horizontal)
+        let centerY = centerYAnchor.constraint(equalTo: object.centerYAnchor, constant: offset.vertical)
 
         disableTranslatesAutoresizingMaskIntoConstraintsIfNeeded()
         NSLayoutConstraint.activate([centerX, centerY])
@@ -76,11 +106,11 @@ extension Pinnable {
     /// - Parameters:
     ///   - object: The object to constrain the receiver to.
     /// - Returns: A named tuple of the created constraints.
-    @discardableResult public func pinSize(
-        to object: Pinnable
+    @discardableResult public func pinSize<P: Pinnable>(
+        to object: P
     ) -> (width: NSLayoutConstraint, height: NSLayoutConstraint) {
-        let height = heightAnchor.pin(to: object.heightAnchor)
-        let width = widthAnchor.pin(to: object.widthAnchor)
+        let height = heightAnchor.constraint(equalTo: object.heightAnchor)
+        let width = widthAnchor.constraint(equalTo: object.widthAnchor)
 
         disableTranslatesAutoresizingMaskIntoConstraintsIfNeeded()
         NSLayoutConstraint.activate([height, width])
@@ -100,8 +130,8 @@ extension Pinnable {
     @discardableResult public func pinSize(
         to size: CGSize
     ) -> (width: NSLayoutConstraint, height: NSLayoutConstraint) {
-        let height = heightAnchor.pin(to: size.height)
-        let width = widthAnchor.pin(to: size.width)
+        let height = heightAnchor.constraint(equalToConstant: size.height)
+        let width = widthAnchor.constraint(equalToConstant: size.width)
 
         disableTranslatesAutoresizingMaskIntoConstraintsIfNeeded()
         NSLayoutConstraint.activate([height, width])


### PR DESCRIPTION
Hi @kylebshr, I made some improvements to the library while using it, and decided to make it upstream so I don't have to maintain my fork.

- Added `priority` parameter to `pinEdges` function.
- Added an overload to `pinEdges` that takes `NSDirectionalRectEdge` and `NSDirectionalEdgeInsets`.
- Made functions that take `Pinnable` generic instead of an existential.
- Added `multiplier` parameter to `NSLayoutAnchor` extension functions.
- Removed `@objc` from 'NSLayoutDimention' functions to fix an Objective-C conflict.
- Fixed redundant/wrong activation calls in `Pinnable` extension functions.
- Lowered the requirements to iOS 9 because why not? 😄 

Happy Holidays!